### PR TITLE
[FR-111] Add keyboard shortcuts

### DIFF
--- a/src/95_renderer.js
+++ b/src/95_renderer.js
@@ -2214,5 +2214,27 @@ function NewRenderer() {
 
 	};
 
+	renderer.load_fen_or_pgn_from_string = function (s) {
+		const str = typeof s === 'string' ? s.trim() : '';
+		let isFen = false;
+		if (str) {
+			try {
+				isFen = LoadFEN(str)
+			} catch (err) {
+				console.log("Load from clipboard: no FEN game, will try as PGN...");
+			}
+
+			if (isFen) {
+				this.load_fen(str);
+				console.log("Clipboard loaded as FEN");
+			} else {
+				this.load_pgn_from_string(s);
+			}
+		} else {
+			console.log("Empty clipboard, game load ignored; input: [%s]", JSON.stringify(s));
+			return;
+		}
+	};
+
 	return renderer;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -316,19 +316,11 @@ function menu_build() {
 					type: "separator"
 				},
 				{
-					label: "Load PGN from clipboard",
+					label: "Load FEN/PGN from clipboard",
+					accelerator: "CommandOrControl+Shift+V",
 					click: () => {
 						win.webContents.send("call", {
-							fn: "load_pgn_from_string",
-							args: [electron.clipboard.readText()]
-						});
-					}
-				},
-				{
-					label: "Load FEN from clipboard",
-					click: () => {
-						win.webContents.send("call", {
-							fn: "load_fen",
+							fn: "load_fen_or_pgn_from_string",
 							args: [electron.clipboard.readText()]
 						});
 					}


### PR DESCRIPTION
LoadFEN() function is used to distinguish clipboard content format:

- [x] will load FEN when the above function succeeded
- [x] otherwise will try to load as PGN
- [x] empty or within whitespace characters clipboard will be ignored
- [x] shortcut/accelerator enabled: CommandOrControl+Shift+V
    - tested on MacOS


Related: #111 
