### PR TITLE
Use regexp for tagline parsing

### DIFF
--- a/src/61_pgn_parse.js
+++ b/src/61_pgn_parse.js
@@ -31,7 +31,7 @@ function PreParsePGN(buf) {							// buf should be the buffer for a single game,
 
 		if (rawline[0] === 91) {
 			let s = decoder.decode(rawline).trim();
-			if (s.endsWith(`"]`)) {
+			if (s.endsWith(`]`)) {
 				tagline = s;
 			}
 		}
@@ -43,22 +43,20 @@ function PreParsePGN(buf) {							// buf should be the buffer for a single game,
 				return game;
 			}
 
-			// Parse the tag line...
+			let m = tagline.match(/^\[\s*(\S+)\s+"?((\\"|\\\\|[^"])+)"?\s*\]$/);
 
-			tagline = tagline.slice(1, -1);			// So now it's like:		Foo "bar etc"
-
-			let quote_i = tagline.indexOf(`"`);
-
-			if (quote_i === -1) {
+			if (!m) {
 				continue;
 			}
 
-			let key = tagline.slice(0, quote_i).trim();
-			let value = tagline.slice(quote_i + 1).trim();
-
-			if (value.endsWith(`"`)) {
-				value = value.slice(0, -1);
-			}
+			let key = m[1];
+			let value = m[2].replaceAll(/\\"|\\\\/g, function (match) {
+				if (match == '\\"') {
+					return '"';
+				} else {
+					return '\\';
+				}
+			});
 
 			game.tags[key] = SafeString(value);		// Escape evil characters. IMPORTANT!
 

--- a/src/misc/setup.pgn
+++ b/src/misc/setup.pgn
@@ -1,0 +1,13 @@
+[Event "Test \"Quotes\" \\ and Escaping"]
+[Site "local"]
+[Date "2021.04.01"]
+[Round "1"]
+[White "Me"]
+[Black "Not Me"]
+[Result "*"]
+[FEN rnbqkb1r/ppp1pppp/5n2/3p4/3P1B2/5N2/PPP1PPPP/RN1QKB1R b KQkq - 3 3]
+[SetUp "1"]
+
+3... c5 {EV: 47.0%, N: 63.14% of 63.4k} 4. e3 {EV: 53.3%, N: 95.14% of 66.9k} e6
+{EV: 47.4%, N: 67.90% of 115k} 5. Nbd2 {EV: 53.1%, N: 67.58% of 96.2k} Qb6 {EV:
+47.8%, N: 77.32% of 198k} 6. Rb1 {EV: 52.7%, N: 90.85% of 166k} *


### PR DESCRIPTION
- This handles escaping of quotes and escaping backslashes in tag values.
- It also allows omitting the quotes in taglines, because some software
  emits such tags.
- Adds setup.pgn to test a board setup position with unquoted FEN value
  and escaped quotes and escape characters.