### PR TITLE
update hash labels

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -3109,6 +3109,30 @@ function menu_build() {
 					label: "Hash",
 					submenu: [
 						{
+							label: "120 GB",
+							type: "checkbox",
+							checked: false,
+							click: () => {
+								win.webContents.send("call", {
+									fn: "set_uci_option_permanent",
+									args: ["Hash", 120 * 1024]
+								});
+								// Will receive an ack IPC which sets menu checks.
+							}
+						},
+						{
+							label: "56 GB",
+							type: "checkbox",
+							checked: false,
+							click: () => {
+								win.webContents.send("call", {
+									fn: "set_uci_option_permanent",
+									args: ["Hash", 56 * 1024]
+								});
+								// Will receive an ack IPC which sets menu checks.
+							}
+						},
+						{
 							label: "24 GB",
 							type: "checkbox",
 							checked: false,
@@ -3116,30 +3140,6 @@ function menu_build() {
 								win.webContents.send("call", {
 									fn: "set_uci_option_permanent",
 									args: ["Hash", 24 * 1024]
-								});
-								// Will receive an ack IPC which sets menu checks.
-							}
-						},
-						{
-							label: "20 GB",
-							type: "checkbox",
-							checked: false,
-							click: () => {
-								win.webContents.send("call", {
-									fn: "set_uci_option_permanent",
-									args: ["Hash", 20 * 1024]
-								});
-								// Will receive an ack IPC which sets menu checks.
-							}
-						},
-						{
-							label: "16 GB",
-							type: "checkbox",
-							checked: false,
-							click: () => {
-								win.webContents.send("call", {
-									fn: "set_uci_option_permanent",
-									args: ["Hash", 16 * 1024]
 								});
 								// Will receive an ack IPC which sets menu checks.
 							}


### PR DESCRIPTION
Main hash options don't make much sense with most common ram configurations, those being 128gb, 64gb, 32gb etc. Changed to max hash size for these cases minus 8gb for os and other tasks, 16gb cannot allocate 100% of ram anyways so 12gb and below is kept as is.