### PR TITLE
Resolves #184: Update Readme and add install script for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,15 @@ For prebuilt binary releases, see the [Releases](https://github.com/rooklift/nib
 
 # Installation - Windows / Linux
 
-Some Windows and Linux standalone releases are uploaded to the [Releases](https://github.com/rooklift/nibbler/releases) section from time to time.
+Some Windows and Linux standalone releases are uploaded to the [Releases](https://github.com/rooklift/nibbler/releases) section from time to time.  
+## Linux install script
+Linux users can make use of the following One Liner to install the latest version of Nibbler:
+```bash
+bash -c "$(wget -O- https://raw.githubusercontent.com/rooklift/nibbler/install_linux/install.sh)"
+```
+* Finds the latest version in [Releases](https://github.com/rooklift/nibbler/releases)
+* Download and extracts the contents to ```/opt/```
+* Optionally, creates a Desktop Shortcut
 
 *Alternatively*, it is possible to run Nibbler from source. This requires Electron, but has no other dependencies. If you have Electron installed (e.g. `npm install -g electron`) you can likely enter the `/src` directory, then do `electron .` to run it. Nibbler should be compatible with at least version 5 and above.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Some Windows and Linux standalone releases are uploaded to the [Releases](https:
 ## Linux install script
 Linux users can make use of the following One Liner to install the latest version of Nibbler:
 ```bash
-bash -c "$(wget -O- https://raw.githubusercontent.com/rooklift/nibbler/install_linux/install.sh)"
+bash -c "$(wget -O- https://raw.githubusercontent.com/rooklift/nibbler/master/src/install.sh)"
 ```
 * Finds the latest version in [Releases](https://github.com/rooklift/nibbler/releases)
 * Download and extracts the contents to ```/opt/```

--- a/install.sh
+++ b/install.sh
@@ -20,15 +20,15 @@ fi
 
 ZIP_NAME="nibbler-${VERSION_NR_ONLY_DIGIT}-linux.zip"
 FILE_NAME="nibbler-${VERSION_NR_ONLY_DIGIT}-linux"
+LOCATION="/opt/${ZIP_NAME}"
+echo "Unzipping to $LOCATION"
 sudo unzip -qq ${ZIP_NAME} -d /opt/
 sudo chmod +x /opt/${FILE_NAME}/nibbler
-echo "Nibbler ${VERSION_NR} is installed in /opt/${FILE_NAME}"
-
 
 read -p "Do you want to create a Desktop Shortcut? (y/n)" -n 1 -r
-echo    # (optional) move to a new line
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
+
    sudo mkdir -p /usr/local/share/applications
 
 cat <<EOF | sudo tee -a /usr/local/share/applications/nibbler.desktop >/dev/null
@@ -42,6 +42,11 @@ Terminal=false
 StartupNotify=false
 Categories=Game;BoardGame;
 EOF
+  printf "\n"
+  echo "Desktop Shortcut created"
 fi
+printf "\n"
+echo "Successfully installed Nibbler ${VERSION_NR} to /opt/${FILE_NAME}"
+
 
 

--- a/install.sh
+++ b/install.sh
@@ -28,9 +28,7 @@ sudo chmod +x /opt/${FILE_NAME}/nibbler
 read -p "Do you want to create a Desktop Shortcut? (y/n)" -n 1 -r
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-
    sudo mkdir -p /usr/local/share/applications
-
 cat <<EOF | sudo tee -a /usr/local/share/applications/nibbler.desktop >/dev/null
 [Desktop Entry]
 Type=Application

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+BASE_URL="https://github.com/rooklift/nibbler/"
+
+# compute the latest release number dynamically
+VERSION_NR=$(basename $(curl -fs -o/dev/null -w %{redirect_url} ${BASE_URL}/releases/latest))
+VERSION_NR_ONLY_DIGIT="${VERSION_NR:1}"
+URL="${BASE_URL}releases/download/${VERSION_NR}/nibbler-${VERSION_NR_ONLY_DIGIT}-linux.zip"
+
+cd ~/Downloads
+echo "Downloading the latest release from the github release page:"
+echo ${URL}
+wget -q -c "${URL}"
+if [ $? -eq 0 ]; then
+    echo "Successfully Downloaded Nibbler ${VERSION_NR_ONLY_DIGIT} "
+else
+    echo "Failed to Download Nibbler ${VERSION_NR_ONLY_DIGIT}. Exiting ..."
+    exit 1
+fi
+
+ZIP_NAME="nibbler-${VERSION_NR_ONLY_DIGIT}-linux.zip"
+FILE_NAME="nibbler-${VERSION_NR_ONLY_DIGIT}-linux"
+sudo unzip -qq ${ZIP_NAME} -d /opt/
+sudo chmod +x /opt/${FILE_NAME}/nibbler
+echo "Nibbler ${VERSION_NR} is installed in /opt/${FILE_NAME}"
+
+
+read -p "Do you want to create a Desktop Shortcut? (y/n)" -n 1 -r
+echo    # (optional) move to a new line
+if [[ $REPLY =~ ^[Yy]$ ]]
+then
+   sudo mkdir -p /usr/local/share/applications
+
+cat <<EOF | sudo tee -a /usr/local/share/applications/nibbler.desktop >/dev/null
+[Desktop Entry]
+Type=Application
+Version=1.0
+Name=Nibbler
+Icon=/opt/${FILE_NAME}/resources/app/pieces/K.png
+Exec=/opt/${FILE_NAME}/nibbler
+Terminal=false
+StartupNotify=false
+Categories=Game;BoardGame;
+EOF
+fi
+
+

--- a/install.sh
+++ b/install.sh
@@ -45,6 +45,6 @@ EOF
 fi
 printf "\n"
 echo "Successfully installed Nibbler ${VERSION_NR} to /opt/${FILE_NAME}"
-
+echo "The Desktop Shortcut will appear shortly in the Applications menu."
 
 

--- a/src/install.sh
+++ b/src/install.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
-
+set -e
 BASE_URL="https://github.com/rooklift/nibbler/"
 
-# compute the latest release number dynamically
+if [ ! -x /usr/bin/curl ] ; then
+    # some extra check if curl is not installed at the usual place
+    command -v curl >/dev/null 2>&1 || { echo >&2 "Please install curl or set it in your path. Aborting."; exit 1; }
+fi
+
+# calculate the latest release number dynamically
 VERSION_NR=$(basename $(curl -fs -o/dev/null -w %{redirect_url} ${BASE_URL}/releases/latest))
+
 VERSION_NR_ONLY_DIGIT="${VERSION_NR:1}"
 URL="${BASE_URL}releases/download/${VERSION_NR}/nibbler-${VERSION_NR_ONLY_DIGIT}-linux.zip"
 
-cd ~/Downloads
-echo "Downloading the latest release from the github release page:"
+cd /tmp
+echo "Downloading the latest release from the github release page ..."
 echo ${URL}
 wget -q -c "${URL}"
 if [ $? -eq 0 ]; then
@@ -21,14 +27,18 @@ fi
 ZIP_NAME="nibbler-${VERSION_NR_ONLY_DIGIT}-linux.zip"
 FILE_NAME="nibbler-${VERSION_NR_ONLY_DIGIT}-linux"
 LOCATION="/opt/${FILE_NAME}"
-echo "Unzipping to $LOCATION"
+echo "Unzipping to $LOCATION, sudo needed"
+echo sudo unzip -qq ${ZIP_NAME} -d /opt/
 sudo unzip -qq ${ZIP_NAME} -d /opt/
 sudo chmod +x /opt/${FILE_NAME}/nibbler
+echo "Successfully extracted Nibbler."
 
-read -p "Do you want to create a Desktop Shortcut? (y/n)" -n 1 -r
+read -p "Would you like to create a Desktop shortcut? (y/n)" -n 1 -r
 if [[ $REPLY =~ ^[Yy]$ ]]
 then
-   sudo mkdir -p /usr/local/share/applications
+printf "\n"
+echo sudo mkdir -p /usr/local/share/applications
+sudo mkdir -p /usr/local/share/applications
 cat <<EOF | sudo tee -a /usr/local/share/applications/nibbler.desktop >/dev/null
 [Desktop Entry]
 Type=Application
@@ -40,11 +50,13 @@ Terminal=false
 StartupNotify=false
 Categories=Game;BoardGame;
 EOF
-  printf "\n"
-  echo "Desktop Shortcut created"
+printf "Desktop shortcut created:/usr/local/share/applications/nibbler.desktop"
+printf "\nThe Desktop shortcut will appear shortly in the applications menu."
+else
+	printf "\nNo Desktop shortcut"
 fi
 printf "\n"
-echo "Successfully installed Nibbler ${VERSION_NR} to /opt/${FILE_NAME}"
-echo "The Desktop Shortcut will appear shortly in the Applications menu."
+echo "Successfully installed Nibbler ${VERSION_NR_ONLY_DIGIT}"
+
 
 

--- a/src/install.sh
+++ b/src/install.sh
@@ -20,7 +20,7 @@ fi
 
 ZIP_NAME="nibbler-${VERSION_NR_ONLY_DIGIT}-linux.zip"
 FILE_NAME="nibbler-${VERSION_NR_ONLY_DIGIT}-linux"
-LOCATION="/opt/${ZIP_NAME}"
+LOCATION="/opt/${FILE_NAME}"
 echo "Unzipping to $LOCATION"
 sudo unzip -qq ${ZIP_NAME} -d /opt/
 sudo chmod +x /opt/${FILE_NAME}/nibbler


### PR DESCRIPTION
This script completely automates the installation for Linux users. The latest version is detected from the [latest releases](https://github.com/rooklift/nibbler/releases/tag/v2.3.6) 

Furthermore, the script will ask if you want to create a Desktop shortcut. The created shortcut looks like this:

![Screenshot from 2022-08-15 23-58-27](https://user-images.githubusercontent.com/36520284/184725961-675da7a9-5b51-40ef-b94d-302c80986325.png)


* Tested on Ubuntu 18.04 and 22.04

