### PR TITLE
added path of icon so it displays the correct icon

### DIFF
--- a/files/src/main.js
+++ b/files/src/main.js
@@ -84,6 +84,7 @@ function startup() {
 		resizable: true,
 		show: false,
 		useContentSize: true,
+		icon: path.join(__dirname, "../nibbler.png"),
 		webPreferences: {
 			backgroundThrottling: false,
 			contextIsolation: false,


### PR DESCRIPTION
Path to icon has to be relative to app directory tree after running _builder.py_ .
Tested on Windows, it now correctly displays the icon app when running Nibbler.exe - both on the dock and on top left corner of the app window.