### PR TITLE
Small tweak to error message (guidance for new developers)

### DIFF
--- a/files/scripts/builder.py
+++ b/files/scripts/builder.py
@@ -1,4 +1,4 @@
-import json, os, shutil, zipfile
+import json, os, platform, shutil, zipfile
 
 zips = {
 	"windows": "scripts/electron_zipped/electron-v9.4.4-win32-x64.zip",
@@ -21,7 +21,10 @@ for key, value in zips.items():
 	
 	# check if electron archives exist
 	if not os.path.exists(value):
-		print("{} not present!".format(value))
+		if key == platform.system().lower():
+			print("{} not present; this is problem if you are hoping to test locally!".format(value))
+		else:
+			print("{} not present, skipping!".format(value))
 		continue
 
 	# make build directory

--- a/files/scripts/builder.py
+++ b/files/scripts/builder.py
@@ -24,7 +24,7 @@ for key, value in zips.items():
 		if key == platform.system().lower():
 			print("{} not present; this is problem if you are hoping to test locally!".format(value))
 		else:
-			print("{} not present, skipping!".format(value))
+			print("Skipping build for {} ({} not present)".format(key, value))
 		continue
 
 	# make build directory
@@ -37,7 +37,7 @@ for key, value in zips.items():
 	shutil.copytree("src", os.path.join(build_res_dir, "app"))
 	
 	# extract electron
-	print("Extracting for {}...".format(key))
+	print("Extracting for {}...".format(key), end='')
 	z = zipfile.ZipFile(value, "r")
 	z.extractall(build_dir)
 	z.close()
@@ -45,5 +45,7 @@ for key, value in zips.items():
 	# rename executable
 	if os.path.exists(os.path.join(build_dir, "electron.exe")):
 		os.rename(os.path.join(build_dir, "electron.exe"), os.path.join(build_dir, "nibbler.exe"))
+		print('OK')
 	if os.path.exists(os.path.join(build_dir, "electron")):
 		os.rename(os.path.join(build_dir, "electron"), os.path.join(build_dir, "nibbler"))
+		print('OK')


### PR DESCRIPTION
## Component

build script

## Changes

Slight adjustment to the error message so it's a bit more user-friendly for first-time developers.

As a new developer, I wasn't sure if `___ not present` was an error or not. Since the instructions https://github.com/rooklift/nibbler/blob/53ts/builder.py#L10-L1263c4095e90b67d/files/scripts/builder.py#L10-L12 specify that you don't need *ALL* platforms, this can help give a little more confidence to someone looking to contribute to nibbler developent for the first time 🙂

## Screenshots

#### Before

![image](https://github.com/rooklift/nibbler/assets/523543/dfb0d4ca-c061-4d55-ab3c-77b9ea78aa47)

#### After

![image](https://github.com/rooklift/nibbler/assets/523543/534e028c-6511-4e8e-9a03-c22601e366df)
