### PR TITLE
Board coordinates are now displayed beside the board

### DIFF
--- a/files/src/nibbler.css
+++ b/files/src/nibbler.css
@@ -24,24 +24,25 @@ body {
 	background-color: #444444;
 }
 
-#boardcoordinates-overlay {
+div.boardcoordinates-wrapper {
 	position: relative;
 	color: white;
 	font-family: monospace;
 }
-#boardcoordinates-vertical {
+
+div.boardcoordinates-1to8 {
 	position: absolute;
 	top: 16px;
 }
 
-#boardcoordinates-horizontal {
+div.boardcoordinates-atoh {
 	position: absolute;
 	left: 16px;
 	top: 0px;
 	display: flex;
 }
 
-#boardcoordinates-horizontal > span {
+div.boardcoordinates-atoh > span {
 	flex-grow: 1;
 	text-align: center;
 }

--- a/files/src/nibbler.css
+++ b/files/src/nibbler.css
@@ -28,12 +28,8 @@ body {
 	position: relative;
 	color: white;
 	font-family: monospace;
-	font-size: 14px;
-	/* calc(448px / 8 / 4) */
 }
 #boardcoordinates-vertical {
-	line-height: 4.0;
-
 	position: absolute;
 	top: 16px;
 }
@@ -43,7 +39,6 @@ body {
 	left: 16px;
 	top: 0px;
 	display: flex;
-	width: 448px;
 }
 
 #boardcoordinates-horizontal > span {

--- a/files/src/nibbler.css
+++ b/files/src/nibbler.css
@@ -24,6 +24,33 @@ body {
 	background-color: #444444;
 }
 
+#boardcoordinates-overlay {
+	position: relative;
+	color: white;
+	font-family: monospace;
+	font-size: 14px;
+	/* calc(448px / 8 / 4) */
+}
+#boardcoordinates-vertical {
+	line-height: 4.0;
+
+	position: absolute;
+	top: 16px;
+}
+
+#boardcoordinates-horizontal {
+	position: absolute;
+	left: 16px;
+	top: 0px;
+	display: flex;
+	width: 448px;
+}
+
+#boardcoordinates-horizontal > span {
+	flex-grow: 1;
+	text-align: center;
+}
+
 #gridder {
 	display: grid;
 	height: 100vh;

--- a/files/src/nibbler.html
+++ b/files/src/nibbler.html
@@ -12,6 +12,13 @@
 
 	<!-- note to self, only use id for things the JS needs to see, they pollute the namespace -->
 
+	<div id="boardcoordinates-overlay">
+		<div id="boardcoordinates-vertical">
+		  8<br>7<br>6<br>5<br>4<br>3<br>2<br>1
+		</div>
+		<div id="boardcoordinates-horizontal"><span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span></div>
+	</div>
+
 	<div id="gridder">
 
 		<table id="boardsquares"></table>

--- a/files/src/nibbler.html
+++ b/files/src/nibbler.html
@@ -12,13 +12,13 @@
 
 	<!-- note to self, only use id for things the JS needs to see, they pollute the namespace -->
 
-	<div id="boardcoordinates-overlay">
-		<div id="boardcoordinates-vertical">
+	<div id="boardcoordinates-overlay" class="boardcoordinates-wrapper">
+		<div id="boardcoordinates-vertical" class="boardcoordinates-1to8">
 		  8<br>7<br>6<br>5<br>4<br>3<br>2<br>1
 		</div>
-		<div id="boardcoordinates-horizontal"><span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span></div>
+		<div id="boardcoordinates-horizontal" class="boardcoordinates-atoh"><span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span></div>
 	</div>
-
+	</div>
 	<div id="gridder">
 
 		<table id="boardsquares"></table>

--- a/files/src/nibbler.html
+++ b/files/src/nibbler.html
@@ -18,6 +18,11 @@
 		</div>
 		<div id="boardcoordinates-horizontal" class="boardcoordinates-atoh"><span>a</span><span>b</span><span>c</span><span>d</span><span>e</span><span>f</span><span>g</span><span>h</span></div>
 	</div>
+	<div id="boardcoordinates-overlay-flipped" class="boardcoordinates-wrapper">
+		<div id="boardcoordinates-vertical-flipped" class="boardcoordinates-1to8">
+		  1<br>2<br>3<br>4<br>5<br>6<br>7<br>8
+		</div>
+		<div id="boardcoordinates-horizontal-flipped" class="boardcoordinates-atoh"><span>h</span><span>g</span><span>f</span><span>e</span><span>d</span><span>c</span><span>b</span><span>a</span></div>
 	</div>
 	<div id="gridder">
 

--- a/files/src/renderer/10_globals.js
+++ b/files/src/renderer/10_globals.js
@@ -5,6 +5,10 @@
 // All of this may be redundant since id-havers are in the global
 // namespace automatically. But declaring them const has some value.
 
+const boardcoordinates_fontsize_px = 14.0;
+const boardcoordinates = document.getElementById("boardcoordinates-overlay");
+const boardcoordinates_v = document.getElementById("boardcoordinates-vertical");
+const boardcoordinates_h = document.getElementById("boardcoordinates-horizontal");
 const boardfriends = document.getElementById("boardfriends");
 const boardsquares = document.getElementById("boardsquares");
 const canvas = document.getElementById("canvas");

--- a/files/src/renderer/10_globals.js
+++ b/files/src/renderer/10_globals.js
@@ -6,9 +6,9 @@
 // namespace automatically. But declaring them const has some value.
 
 const boardcoordinates_fontsize_px = 14.0;
-const boardcoordinates = document.getElementById("boardcoordinates-overlay");
-const boardcoordinates_v = document.getElementById("boardcoordinates-vertical");
-const boardcoordinates_h = document.getElementById("boardcoordinates-horizontal");
+const boardcoordinates = [document.getElementById("boardcoordinates-overlay"), document.getElementById("boardcoordinates-overlay-flipped")];
+const boardcoordinates_v = [document.getElementById("boardcoordinates-vertical"), document.getElementById("boardcoordinates-vertical-flipped")];
+const boardcoordinates_h = [document.getElementById("boardcoordinates-horizontal"), document.getElementById("boardcoordinates-horizontal-flipped")];
 const boardfriends = document.getElementById("boardfriends");
 const boardsquares = document.getElementById("boardsquares");
 const canvas = document.getElementById("canvas");

--- a/files/src/renderer/95_hub.js
+++ b/files/src/renderer/95_hub.js
@@ -2223,6 +2223,10 @@ let hub_props = {
 			}
 		}
 
+		// Update coordinates visibility (flipped vs. not flipped) using the same code as in the longer version in renderer/99_start.js, which this does not replace.
+		boardcoordinates[0].style.visibility = config.flip ? 'hidden' : 'visible';
+		boardcoordinates[1].style.visibility = config.flip ? 'visible' : 'hidden';
+
 		this.draw();								// For the canvas stuff.
 	},
 
@@ -2344,8 +2348,8 @@ let hub_props = {
 
 		// This assumes everything already exists.
 		// Derived from the longer version in renderer/99_start.js, which it does not replace.
-		boardcoordinates_h.style.width = config.board_size + 'px';
-		boardcoordinates_v.style.lineHeight = config.board_size / boardcoordinates_fontsize_px / 8.0;
+		boardcoordinates_v.forEach( function(bc_v) { bc_v.style.lineHeight = config.board_size / 8.0 / boardcoordinates_fontsize_px; } );
+		boardcoordinates_h.forEach( function(bc_h) { bc_h.style.width = config.board_size + 'px'; } );
 
 		boardfriends.width = canvas.width = boardsquares.width = config.board_size;
 		boardfriends.height = canvas.height = boardsquares.height = config.board_size;

--- a/files/src/renderer/95_hub.js
+++ b/files/src/renderer/95_hub.js
@@ -2343,7 +2343,9 @@ let hub_props = {
 	rebuild_sizes: function() {
 
 		// This assumes everything already exists.
-		// Derived from the longer version in start.js, which it does not replace.
+		// Derived from the longer version in renderer/99_start.js, which it does not replace.
+		boardcoordinates_h.style.width = config.board_size + 'px';
+		boardcoordinates_v.style.lineHeight = config.board_size / boardcoordinates_fontsize_px / 8.0;
 
 		boardfriends.width = canvas.width = boardsquares.width = config.board_size;
 		boardfriends.height = canvas.height = boardsquares.height = config.board_size;

--- a/files/src/renderer/99_start.js
+++ b/files/src/renderer/99_start.js
@@ -38,10 +38,14 @@ fenbox.value = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 // boardsquares has its natural position, while the other three get
 // fixed position that is set to be on top of it.
 
+boardcoordinates[0].style.visibility = config.flip ? 'hidden' : 'visible';
+boardcoordinates[1].style.visibility = config.flip ? 'visible' : 'hidden';
+
 // There are 8 squares on a chessboard, so boardcoordinates_v.style.lineHeight should be exactly 1 square in height
-boardcoordinates_v.style.lineHeight = config.board_size / 8.0 / boardcoordinates_fontsize_px
-boardcoordinates_h.style.width = config.board_size + 'px';
-boardcoordinates.style.fontSize = boardcoordinates_fontsize_px + 'px';
+boardcoordinates_v.forEach( function(bc_v) { bc_v.style.lineHeight = config.board_size / 8.0 / boardcoordinates_fontsize_px; } );
+boardcoordinates_h.forEach( function(bc_h) { bc_h.style.width = config.board_size + 'px'; } );
+boardcoordinates.forEach( function(bc) { bc.style.fontSize = boardcoordinates_fontsize_px + 'px'; } );
+
 boardfriends.width = canvas.width = boardsquares.width = config.board_size;
 boardfriends.height = canvas.height = boardsquares.height = config.board_size;
 

--- a/files/src/renderer/99_start.js
+++ b/files/src/renderer/99_start.js
@@ -38,6 +38,10 @@ fenbox.value = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 // boardsquares has its natural position, while the other three get
 // fixed position that is set to be on top of it.
 
+// There are 8 squares on a chessboard, so boardcoordinates_v.style.lineHeight should be exactly 1 square in height
+boardcoordinates_v.style.lineHeight = config.board_size / 8.0 / boardcoordinates_fontsize_px
+boardcoordinates_h.style.width = config.board_size + 'px';
+boardcoordinates.style.fontSize = boardcoordinates_fontsize_px + 'px';
 boardfriends.width = canvas.width = boardsquares.width = config.board_size;
 boardfriends.height = canvas.height = boardsquares.height = config.board_size;
 


### PR DESCRIPTION
## Resolves

- "Coordinates" mentioned in https://github.com/rooklift/nibbler/issues/10

## Implemented in this PR

- Dynamic coordinates based on `config.board_size`
- Dynamic coordinates based on `config.flip`

## Screenshots

Tested working locally

![image](https://github.com/rooklift/nibbler/assets/523543/67bb1167-0f30-4ef3-ae21-f06c5e0200ab)
