### PR TITLE
When a move happens to be the "top engine move", it will now appear as bold in the movelist (tree view)

### DIFF
--- a/files/src/renderer/50_table.js
+++ b/files/src/renderer/50_table.js
@@ -18,6 +18,7 @@ const table_prototype = {
 		this.tbhits = 0;						// Stat sent by engine
 		this.time = 0;							// Stat sent by engine
 		this.limit = null;						// The limit of the last search that updated this.
+		this.bestmove_so_far = null					// The "top engine move" move e.g. 'e7e5'
 		this.terminal = null;					// null = unknown, "" = not terminal, "Non-empty string" = terminal reason
 		this.eval = null;						// Used by grapher only, value from White's POV
 		this.eval_version = 0;					// Which version (above) was used to generate the eval

--- a/files/src/renderer/72_tree_draw.js
+++ b/files/src/renderer/72_tree_draw.js
@@ -7,6 +7,15 @@ let tree_draw_props = {
 	ordered_nodes_cache: null,
 	ordered_nodes_cache_version: -1,
 
+	dom_bold_bestmove_child: function(node) {
+		let bestmove_move = node.table.bestmove_so_far;
+
+		node.children.forEach( function(child_node) {
+			let dom_child_node = document.getElementById(`node_${child_node.id}`);
+			dom_child_node.style.fontWeight = (bestmove_move == child_node.move) ? 'bold' : 'normal';
+		});
+	},
+
 	dom_easy_highlight_change: function() {
 
 		// When the previously highlighted node and the newly highlighted node are on the same line,
@@ -57,6 +66,7 @@ let tree_draw_props = {
 			this.ordered_nodes_cache_version = this.tree_version;
 		}
 
+		let dom_bestmove_fontweight_ids = [];
 		let pseudoelements = [];		// Objects containing opening span string `<span foo>` and text string
 
 		for (let item of this.ordered_nodes_cache) {
@@ -94,6 +104,10 @@ let tree_draw_props = {
 				classes.push("white");		// Otherwise, inherits gray colour from movelist CSS
 			}
 
+			if ((node.parent !== null) && (node.parent.table.bestmove_so_far !== null) && (node.parent.table.bestmove_so_far == node.move)) {
+				dom_bestmove_fontweight_ids.push(node.id);
+			}
+
 			pseudoelements.push({
 				opener: `<span class="${classes.join(" ")}" id="node_${node.id}">`,
 				text: node.token(),
@@ -116,6 +130,10 @@ let tree_draw_props = {
 		}
 
 		movelist.innerHTML = all_spans.join("");
+
+		dom_bestmove_fontweight_ids.forEach( function(node_id) {
+			document.getElementById(`node_${node_id}`).style.fontWeight = 'bold';
+		});
 
 		// Undo the damage to our tree from the start...
 

--- a/files/src/renderer/90_engine.js
+++ b/files/src/renderer/90_engine.js
@@ -270,12 +270,19 @@ function NewEngine(hub) {
 		this.send("ucinewgame");
 	};
 
+	// e.g. `line` might be "bestmove e7e5 ponder g1f3"
 	eng.handle_bestmove_line = function(line) {
 
 		this.search_completed = this.search_running;
 		this.search_running = NoSearch;
 
 		this.unresolved_stop_time = null;
+
+		if (this.search_completed.node.table !== null) {
+			let tokens = line.split(" ").filter(z => z !== "");
+			this.search_completed.node.table.bestmove_so_far = tokens[1];
+			this.hub.tree.dom_bold_bestmove_child(this.search_completed.node);
+		}
 
 		// If this.search_desired === this.search_running then the search that just completed is
 		// the most recent one requested by the hub; we have nothing to replace it with.

--- a/files/src/renderer/95_hub.js
+++ b/files/src/renderer/95_hub.js
@@ -968,6 +968,7 @@ let hub_props = {
 				break;
 			}
 
+			// e.g. `s` might be 'bestmove e7e5 ponder g1f3'
 			let tokens = s.split(" ").filter(z => z !== "");
 			ok = this.move(tokens[1]);
 


### PR DESCRIPTION
## Components affected

- Engine
- Movelist / Tree View

## Implemented in this Pull Request

When receiving a "bestmove" line from the engine, store the result in `node.table`

When rendering the Movelist / Tree View, any move that was the top engine move appears in bold.

When comparing engine performance to top level play, this can make it quicker to identify moments in the game that are paying giving more attention to.

## Testing

![image](https://github.com/rooklift/nibbler/assets/523543/78f8f5f5-f79e-4f19-b426-105bace7f8b1)
