### PR TITLE
`builder.py`: Add note on Electron versions

### DIFF
--- a/files/scripts/builder.py
+++ b/files/scripts/builder.py
@@ -10,6 +10,8 @@ zips = {
 # Obtain the appropriate Electron asset named above, from https://github.com/electron/electron/releases
 # Create a folder at scripts/electron_zipped and place the Electron asset in it
 # Run ./builder.py
+#
+# Note: later Electron versions aren't yet supported: https://github.com/rooklift/nibbler/issues/140
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))		# Ensure we're in builder.py's directory.
 os.chdir("..")												# Then come up one level.

--- a/files/scripts/builder.py
+++ b/files/scripts/builder.py
@@ -11,7 +11,8 @@ zips = {
 # Create a folder at scripts/electron_zipped and place the Electron asset in it
 # Run ./builder.py
 #
-# Note: later Electron versions aren't yet supported: https://github.com/rooklift/nibbler/issues/140
+# Note: later Electron versions work also, but with a couple minor glitches:
+# https://github.com/rooklift/nibbler/issues/140
 
 os.chdir(os.path.dirname(os.path.realpath(__file__)))		# Ensure we're in builder.py's directory.
 os.chdir("..")												# Then come up one level.


### PR DESCRIPTION
Latest is v27, Nibbler says v9, worth noting why so behind