### PR TITLE
Draw a faint shaded area around the eval line to indicate the likeliness of a decisive result

### DIFF
--- a/files/src/renderer/50_table.js
+++ b/files/src/renderer/50_table.js
@@ -20,11 +20,13 @@ const table_prototype = {
 		this.limit = null;						// The limit of the last search that updated this.
 		this.terminal = null;					// null = unknown, "" = not terminal, "Non-empty string" = terminal reason
 		this.graph_y = null;					// Used by grapher only, value from White's POV between 0 and 1
+		this.graph_y_drawishness = null;			// Used by grapher only, drawishness between 0 and 1
 		this.graph_y_version = 0;				// Which version (above) was used to generate the graph_y value
 		this.already_autopopulated = false;
 	},
 
-	get_graph_y: function() {
+	// returns {'graph_y': number between 0.0 and 1.0, 'drawishness': number between 0.0 and 1.0}
+	get_graph_y_details: function() {
 
 		// Naphthalin's scheme: based on centipawns.
 
@@ -36,12 +38,19 @@ const table_prototype = {
 					cp *= -1;
 				}
 				this.graph_y = 1 / (1 + Math.pow(0.5, cp / 100));
+
+				if (info.wdl === null) {
+					this.graph_y_drawishness = null;
+				} else {
+					this.graph_y_drawishness = info.wdl[1] / 1000.0;
+				}
 			} else {
 				this.graph_y = null;
+				this.graph_y_drawishness = null;
 			}
 			this.graph_y_version = this.version;
 		}
-		return this.graph_y;
+		return {'graph_y': this.graph_y, 'drawishness': this.graph_y_drawishness};
 	},
 
 	set_terminal_info: function(reason, ev) {	// ev is ignored if reason is "" (i.e. not a terminal position)

--- a/files/src/renderer/50_table.js
+++ b/files/src/renderer/50_table.js
@@ -28,9 +28,7 @@ const table_prototype = {
 
 		// Naphthalin's scheme: based on centipawns.
 
-		if (this.graph_y_version === this.version) {
-			return this.graph_y;
-		} else {
+		if (this.graph_y_version !== this.version) {
 			let info = SortedMoveInfoFromTable(this)[0];
 			if (info && !info.__ghost && info.__touched && (this.nodes > 1 || this.limit === 1)) {
 				let cp = info.cp;
@@ -42,8 +40,8 @@ const table_prototype = {
 				this.graph_y = null;
 			}
 			this.graph_y_version = this.version;
-			return this.graph_y;
 		}
+		return this.graph_y;
 	},
 
 	set_terminal_info: function(reason, ev) {	// ev is ignored if reason is "" (i.e. not a terminal position)

--- a/files/src/renderer/51_node.js
+++ b/files/src/renderer/51_node.js
@@ -125,6 +125,7 @@ const node_prototype = {
 		return ret;
 	},
 
+	// returns an array of {'graph_y': number between 0.0 and 1.0, 'drawishness': number between 0.0 and 1.0}
 	all_graph_values: function() {
 
 		// Call this on any node in the line will give the same result.
@@ -133,7 +134,7 @@ const node_prototype = {
 		let node = this.get_end();
 
 		while (node) {
-			ret.push(node.table.get_graph_y());
+			ret.push(node.table.get_graph_y_details());
 			node = node.parent;
 		}
 

--- a/files/src/renderer/55_winrate_graph.js
+++ b/files/src/renderer/55_winrate_graph.js
@@ -39,6 +39,8 @@ function NewGrapher() {
 
 		let runs = this.make_runs(eval_list, width, height, node.graph_length_knower.val);
 
+		graphctx.fillStyle = 'rgba(255, 255, 255, 0.25)';
+
 		// Draw our normal runs...
 
 		graphctx.strokeStyle = "white";
@@ -47,6 +49,26 @@ function NewGrapher() {
 		graphctx.setLineDash([]);
 
 		for (let run of runs.normal_runs) {
+			// Drawishness fill
+			let drawishness_fill = new Path2D();
+			if (run[0].y_shaded1 !== null) {
+				drawishness_fill.moveTo(run[0].x1, run[0].y1 + run[0].y_shaded1);
+				for (let edge of run) {
+					if (edge.y_shaded2 !== null) {
+						drawishness_fill.lineTo(edge.x2, edge.y2 + edge.y_shaded2);
+					}
+				}
+			}
+			if (run[run.length - 1].y_shaded2 !== null) {
+				drawishness_fill.lineTo(run[run.length - 1].x2, run[run.length - 1].y2 + run[run.length - 1].y_shaded2);
+				for (let edge of run.reverse()) {
+					if (edge.y_shaded1 !== null) {
+						drawishness_fill.lineTo(edge.x1, edge.y1 - edge.y_shaded1);
+					}
+				}
+			}
+			graphctx.fill(drawishness_fill);
+
 			// Evaluation line
 			graphctx.beginPath();
 			graphctx.moveTo(run[0].x1, run[0].y1);

--- a/files/src/renderer/55_winrate_graph.js
+++ b/files/src/renderer/55_winrate_graph.js
@@ -47,6 +47,7 @@ function NewGrapher() {
 		graphctx.setLineDash([]);
 
 		for (let run of runs.normal_runs) {
+			// Evaluation line
 			graphctx.beginPath();
 			graphctx.moveTo(run[0].x1, run[0].y1);
 			for (let edge of run) {


### PR DESCRIPTION
Showing "decisive" vs. "dead drawn" in some way allows Nibbler users to:

* (when eval is close to zero) users can easily identify which "drawn" positions are actually dead drawn vs. unclear/complex/sharp
* (when eval favors one side) users can easily identify which portions of the game contain more counterplay/complexity, despite the advantage

### Testing

(screenshot using the well known **Kramnik vs. Topalov** World Chess Championship 2006, Game 4)

<img width="1542" alt="image" src="https://github.com/rooklift/nibbler/assets/523543/d072cd23-b762-4bd4-864b-457e708bb5cb">


(screenshot using the famous **Kasparov vs. Karpov** World Chess Championship 1987, Game 24)

[]

(screenshot of a more recent game **Anand vs. Gelfand**  World Chess Championship 2012, Game 7)

[]

(screenshot using the famous "dead drawn" game **Carlsen vs. Caruana** World Chess Championship 2018, Game 12)

