### PR TITLE
The move number now appears as you hover the Eval Line (about to click on a move) so you know which move you're clicking on

### DIFF
--- a/files/src/renderer/10_globals.js
+++ b/files/src/renderer/10_globals.js
@@ -49,6 +49,7 @@ const util = require("util");
 
 // Globals..........................................................
 
+// https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext
 const boardctx = canvas.getContext("2d");
 const graphctx = graph.getContext("2d");
 const decoder = new util.TextDecoder("utf8");	// https://github.com/electron/electron/issues/18733

--- a/files/src/renderer/55_winrate_graph.js
+++ b/files/src/renderer/55_winrate_graph.js
@@ -77,7 +77,7 @@ function NewGrapher() {
 	grapher.draw_hover_annotation = function() {
 		let node = this.last_hover_node;
 
-		if ((node === null) || (node.move === null)) {
+		if ((node === null) || (node.move === null) || (node.graph_length_knower === null)) {
 			return;
 		}
 

--- a/files/src/renderer/95_hub.js
+++ b/files/src/renderer/95_hub.js
@@ -2019,6 +2019,7 @@ let hub_props = {
 		}
 	},
 
+	// User clicks the "winrate" line, so take them to that move.
 	winrate_click: function(event) {
 
 		let node = this.grapher.node_from_click(this.tree.node, event);
@@ -2031,6 +2032,24 @@ let hub_props = {
 			this.position_changed(false, true);
 		}
 	},
+	// User hovers the "winrate" line graph
+	winrate_hover: function(event) {
+
+		if (!this.grapher.is_inside_graph_canvas(event)) {
+			this.grapher.last_hover_node = null;
+			return;
+		}
+
+		let node = this.grapher.node_from_click(this.tree.node, event);
+
+		if (!node) {
+			return;
+		}
+
+		this.grapher.last_hover_node = node;
+		this.grapher.draw_hover_annotation();
+	},
+
 
 	statusbox_click: function(event) {
 

--- a/files/src/renderer/99_start.js
+++ b/files/src/renderer/99_start.js
@@ -190,6 +190,7 @@ for (let s of ["mousemove", "mouseleave"]) {
 
 	graph.addEventListener(s, (event) => {
 		if (!hub.grapher.dragging) {
+			hub.winrate_hover(event);
 			return;
 		}
 		if (!event.buttons) {


### PR DESCRIPTION
### Summary

This is a simpler version of https://github.com/rooklift/nibbler/pull/235 containing only the Move Number / Token annotation, and without all the eval stuff.

<img width="1264" alt="image" src="https://github.com/rooklift/nibbler/assets/523543/7bb475ac-e966-4f3c-bbdd-bf9170f7bf20">

### Purpose

When hovering the mouse, show the move token of the move you are hovering over.
This makes it easier for users to pinpoint which specific move that they are about to jump to, before they click on a specific move with their mouse.