### PR TITLE
Add MacOS installer script

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ curl -L https://raw.githubusercontent.com/rooklift/nibbler/master/files/scripts/
 
 Mac builds have been made by [twoplan](https://github.com/twoplan/Nibbler-for-macOS) and [Jac-Zac](https://github.com/Jac-Zac/Nibbler_MacOS) and [Zamana](https://github.com/Zamana/nibbler) - the last of which is probably the most up-to-date.
 
+Alternatively, MacOS users can run the following *one-liner* to assemble Nibbler locally. This removes any codesigning issues (Gatekeeper refusing to open unauthorized apps) by building Nibbler on-the-fly.
+```bash
+curl -L https://raw.githubusercontent.com/rooklift/nibbler/master/files/scripts/install-macos.sh | bash
+```
+
 ## Advanced engine options
 
 Most people won't need them, but all of Leela's engine options can be set in two ways:

--- a/files/scripts/install-macos.sh
+++ b/files/scripts/install-macos.sh
@@ -15,6 +15,17 @@ VERSION="2.5.7"
 NODE_VERSION="25.8.1"
 PACKAGE_NAME="nibbler"
 PACKAGE_MAIN="files/src/main.js"
+NODE_ARCH="arm64"
+
+
+# robustness fix... clean exit
+cleanup_on_failure() {
+	local exit_code="$1"
+	if [[ "$exit_code" -ne 0 ]]; then
+		rm -rf "$WORKDIR"
+	fi
+}
+trap 'cleanup_on_failure "$?"' EXIT
 
 # electron packager fails without name, version, main fields in package.json
 # this uses simple js script to ensure correct fields
@@ -64,6 +75,7 @@ fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
 EOF
 }
 
+rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR"
 cd "$WORKDIR"
 
@@ -74,14 +86,13 @@ msg "Unzipping nibbler archive..."
 unzip -q "v${VERSION}.zip"
 
 NIBBLER="nibbler-${VERSION}"
-ls "$NIBBLER" && ok "Fetched nibbler!"
+[[ -d "$NIBBLER" ]] && ok "Fetched nibbler!"
 
 ARCH="$(uname -m)"
-case "$ARCH" in
-  arm64) NODE_ARCH="arm64" ;;
-  x86_64) msg "Unsupported architecture: x86" >&2; exit 1;;
-  *) msg "Unsupported architecture: $ARCH" >&2; exit 1 ;;
-esac
+if [[ "$ARCH" != "$NODE_ARCH" ]]; then
+	msg "Unsupported architecture: $ARCH (this installer requires ${NODE_ARCH})" >&2
+	exit 1
+fi
 
 NODE_DIR="node-v${NODE_VERSION}-darwin-${NODE_ARCH}"
 NODE_TGZ="${NODE_DIR}.tar.gz"
@@ -92,7 +103,7 @@ curl -fL -O "https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TGZ}"
 msg "Unpacking node archive..."
 tar -xzf "$NODE_TGZ"
 
-ls "$NODE_DIR" && ok "Fetched node!"
+[[ -d "$NODE_DIR" ]] && ok "Fetched node!"
 
 msg "Verifying npm, npx..."
 NODE="$WORKDIR/$NODE_DIR/bin/node"
@@ -117,7 +128,22 @@ msg "Running electron-packager..."
 "$NPX" @electron/packager . Nibbler --platform=darwin --arch="$NODE_ARCH" --out=dist
 ok "Built app!"
 
-msg "Nice, here you go!"
-open "$WORKDIR/$NIBBLER/dist/Nibbler-darwin-arm64/"
+APP_DIR="$WORKDIR/$NIBBLER/dist/Nibbler-darwin-${NODE_ARCH}"
+APP="$APP_DIR/Nibbler.app"
+APPS_DIR="$HOME/Applications"
+APPS_APP="$APPS_DIR/Nibbler.app"
 
-msg "IMPORTANT: Make sure to move app under Applications/ or ~/Applications!"
+read -r -p "Move Nibbler.app to ~/Applications and overwrite any existing copy? [Y/n] " MOVE_APP
+
+msg "Nice, here you go!"
+if [[ -z "$MOVE_APP" || "$MOVE_APP" =~ ^[Yy]$ ]]; then
+	msg "Installing Nibbler.app to ~/Applications..."
+	mkdir -p "$APPS_DIR"
+	rm -rf "$APPS_APP"
+	mv "$APP" "$APPS_DIR/"
+	ok "Installed Nibbler.app to ${APPS_APP}!"
+	open -R "$APPS_APP"
+else
+	open "$APP_DIR"
+	msg "IMPORTANT: Make sure to move app under Applications/ or ~/Applications!"
+fi

--- a/files/scripts/install-macos.sh
+++ b/files/scripts/install-macos.sh
@@ -16,6 +16,7 @@ NODE_VERSION="25.8.1"
 PACKAGE_NAME="nibbler"
 PACKAGE_MAIN="files/src/main.js"
 NODE_ARCH="arm64"
+SOURCE_DIR="files/src"
 
 
 # robustness fix... clean exit
@@ -26,54 +27,6 @@ cleanup_on_failure() {
 	fi
 }
 trap 'cleanup_on_failure "$?"' EXIT
-
-# electron packager fails without name, version, main fields in package.json
-# this uses simple js script to ensure correct fields
-ensure_package_json_defaults() {
-	local package_json_path="$1"
-	local package_name="$2"
-	local package_version="$3"
-	local package_main="$4"
-
-	"$NODE" - "$package_json_path" "$package_name" "$package_version" "$package_main" <<'EOF'
-const fs = require("fs");
-
-const [packageJsonPath, packageName, packageVersion, packageMain] = process.argv.slice(2);
-let pkg = {};
-
-if (fs.existsSync(packageJsonPath)) {
-	const raw = fs.readFileSync(packageJsonPath, "utf8").trim();
-
-	if (raw !== "") {
-		try {
-			pkg = JSON.parse(raw);
-		} catch (error) {
-			console.error(`Invalid JSON in ${packageJsonPath}: ${error.message}`);
-			process.exit(1);
-		}
-	}
-}
-
-if (pkg === null || Array.isArray(pkg) || typeof pkg !== "object") {
-	console.error(`${packageJsonPath} must contain a JSON object.`);
-	process.exit(1);
-}
-
-if (typeof pkg.name !== "string" || pkg.name.trim() === "") {
-	pkg.name = packageName;
-}
-
-if (typeof pkg.version !== "string" || pkg.version.trim() === "") {
-	pkg.version = packageVersion;
-}
-
-if (typeof pkg.main !== "string" || pkg.main.trim() === "") {
-	pkg.main = packageMain;
-}
-
-fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
-EOF
-}
 
 rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR"
@@ -120,15 +73,15 @@ msg "Installing electron and electron-packager..."
 "$NPM" install --save-dev electron @electron/packager
 ok "Installed packages!"
 
-msg "Ensuring package.json has required Electron entry fields..."
-ensure_package_json_defaults "package.json" "$PACKAGE_NAME" "$VERSION" "$PACKAGE_MAIN"
-ok "Prepared package.json!"
+cd "$WORKDIR/$NIBBLER/$SOURCE_DIR"
 
 msg "Running electron-packager..."
 "$NPX" @electron/packager . Nibbler --platform=darwin --arch="$NODE_ARCH" --out=dist
 ok "Built app!"
 
-APP_DIR="$WORKDIR/$NIBBLER/dist/Nibbler-darwin-${NODE_ARCH}"
+
+cd "$WORKDIR/$NIBBLER"
+APP_DIR="$WORKDIR/$NIBBLER/$SOURCE_DIR/dist/Nibbler-darwin-${NODE_ARCH}"
 APP="$APP_DIR/Nibbler.app"
 APPS_DIR="$HOME/Applications"
 APPS_APP="$APPS_DIR/Nibbler.app"

--- a/files/scripts/install-macos.sh
+++ b/files/scripts/install-macos.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+set -euo pipefail
+
+msg() {
+	printf "=======================\n"
+	printf "\033[93m%s\033[0m\n" "$1"
+}
+
+ok() {
+	printf "\033[92m \u2714 %s\033[0m\n" "$1"
+}
+
+WORKDIR="/tmp/nibbler-install"
+VERSION="2.5.7"
+NODE_VERSION="25.8.1"
+PACKAGE_NAME="nibbler"
+PACKAGE_MAIN="files/src/main.js"
+
+# electron packager fails without name, version, main fields in package.json
+# this uses simple js script to ensure correct fields
+ensure_package_json_defaults() {
+	local package_json_path="$1"
+	local package_name="$2"
+	local package_version="$3"
+	local package_main="$4"
+
+	"$NODE" - "$package_json_path" "$package_name" "$package_version" "$package_main" <<'EOF'
+const fs = require("fs");
+
+const [packageJsonPath, packageName, packageVersion, packageMain] = process.argv.slice(2);
+let pkg = {};
+
+if (fs.existsSync(packageJsonPath)) {
+	const raw = fs.readFileSync(packageJsonPath, "utf8").trim();
+
+	if (raw !== "") {
+		try {
+			pkg = JSON.parse(raw);
+		} catch (error) {
+			console.error(`Invalid JSON in ${packageJsonPath}: ${error.message}`);
+			process.exit(1);
+		}
+	}
+}
+
+if (pkg === null || Array.isArray(pkg) || typeof pkg !== "object") {
+	console.error(`${packageJsonPath} must contain a JSON object.`);
+	process.exit(1);
+}
+
+if (typeof pkg.name !== "string" || pkg.name.trim() === "") {
+	pkg.name = packageName;
+}
+
+if (typeof pkg.version !== "string" || pkg.version.trim() === "") {
+	pkg.version = packageVersion;
+}
+
+if (typeof pkg.main !== "string" || pkg.main.trim() === "") {
+	pkg.main = packageMain;
+}
+
+fs.writeFileSync(packageJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
+EOF
+}
+
+mkdir -p "$WORKDIR"
+cd "$WORKDIR"
+
+msg "Downloading nibbler archive..."
+curl -fL -O "https://github.com/rooklift/nibbler/archive/refs/tags/v${VERSION}.zip"
+
+msg "Unzipping nibbler archive..."
+unzip -q "v${VERSION}.zip"
+
+NIBBLER="nibbler-${VERSION}"
+ls "$NIBBLER" && ok "Fetched nibbler!"
+
+ARCH="$(uname -m)"
+case "$ARCH" in
+  arm64) NODE_ARCH="arm64" ;;
+  x86_64) msg "Unsupported architecture: x86" >&2; exit 1;;
+  *) msg "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
+
+NODE_DIR="node-v${NODE_VERSION}-darwin-${NODE_ARCH}"
+NODE_TGZ="${NODE_DIR}.tar.gz"
+
+msg "Downloading node archive..."
+curl -fL -O "https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TGZ}"
+
+msg "Unpacking node archive..."
+tar -xzf "$NODE_TGZ"
+
+ls "$NODE_DIR" && ok "Fetched node!"
+
+msg "Verifying npm, npx..."
+NODE="$WORKDIR/$NODE_DIR/bin/node"
+NPM="$WORKDIR/$NODE_DIR/bin/npm"
+NPX="$WORKDIR/$NODE_DIR/bin/npx"
+
+"$NODE" --version
+"$NPM" --version
+"$NPX" --version
+
+cd "$WORKDIR/$NIBBLER"
+
+msg "Installing electron and electron-packager..."
+"$NPM" install --save-dev electron @electron/packager
+ok "Installed packages!"
+
+msg "Ensuring package.json has required Electron entry fields..."
+ensure_package_json_defaults "package.json" "$PACKAGE_NAME" "$VERSION" "$PACKAGE_MAIN"
+ok "Prepared package.json!"
+
+msg "Running electron-packager..."
+"$NPX" @electron/packager . Nibbler --platform=darwin --arch="$NODE_ARCH" --out=dist
+ok "Built app!"
+
+msg "Nice, here you go!"
+open "$WORKDIR/$NIBBLER/dist/Nibbler-darwin-arm64/"
+
+msg "IMPORTANT: Make sure to move app under Applications/ or ~/Applications!"

--- a/files/scripts/install-macos.sh
+++ b/files/scripts/install-macos.sh
@@ -12,7 +12,7 @@ ok() {
 
 WORKDIR="/tmp/nibbler-install"
 VERSION="2.5.7"
-ELECTRON_VERSION="v41.0.3"
+ELECTRON_VERSION="41.0.3"
 
 ARCH="$(uname -m)"
 case "$ARCH" in
@@ -38,16 +38,18 @@ msg "Downloading nibbler v${VERSION}..."
 curl -# -fL -O "https://github.com/rooklift/nibbler/archive/refs/tags/v${VERSION}.zip"
 unzip -q "v${VERSION}.zip"
 NIBBLER="nibbler-${VERSION}"
-[[ -d "$NIBBLER" ]] && ok "Fetched nibbler!"
+[[ -d "$NIBBLER" ]] || { msg "Failed to fetch nibbler..."; exit 1; }
+ok "Fetched nibbler!"
 
-msg "Downloading Electron v${ELECTRON_VERSION}..."
-ELECTRON_ZIP="electron-${ELECTRON_VERSION}-darwin-${ELECTRON_ARCH}.zip"
-curl -# -fL -O "https://github.com/electron/electron/releases/download/${ELECTRON_VERSION}/${ELECTRON_ZIP}"
+msg "Downloading electron v${ELECTRON_VERSION}..."
+ELECTRON_ZIP="electron-v${ELECTRON_VERSION}-darwin-${ELECTRON_ARCH}.zip"
+curl -# -fL -O "https://github.com/electron/electron/releases/download/v${ELECTRON_VERSION}/${ELECTRON_ZIP}"
 
 mkdir -p electron
 cd electron
 unzip -q "../${ELECTRON_ZIP}"
-[[ -d "$WORKDIR/electron/Electron.app" ]] && ok "Fetched Electron!"
+[[ -d "$WORKDIR/electron/Electron.app" ]] || { msg "Failed to fetch electron..."; exit 1; }
+ok "Fetched electron!"
 
 msg "Assembling Nibbler.app..."
 APP="$WORKDIR/electron/Electron.app"

--- a/files/scripts/install-macos.sh
+++ b/files/scripts/install-macos.sh
@@ -12,12 +12,14 @@ ok() {
 
 WORKDIR="/tmp/nibbler-install"
 VERSION="2.5.7"
-NODE_VERSION="25.8.1"
-PACKAGE_NAME="nibbler"
-PACKAGE_MAIN="files/src/main.js"
-NODE_ARCH="arm64"
-SOURCE_DIR="files/src"
+ELECTRON_VERSION="v41.0.3"
 
+ARCH="$(uname -m)"
+case "$ARCH" in
+	arm64) ELECTRON_ARCH="arm64" ;;
+	x86_64) ELECTRON_ARCH="x64" ;;
+	*) msg "Unsupported architecture: $ARCH" >&2; exit 1 ;;
+esac
 
 # robustness fix... clean exit
 cleanup_on_failure() {
@@ -32,56 +34,38 @@ rm -rf "$WORKDIR"
 mkdir -p "$WORKDIR"
 cd "$WORKDIR"
 
-msg "Downloading nibbler archive..."
-curl -fL -O "https://github.com/rooklift/nibbler/archive/refs/tags/v${VERSION}.zip"
-
-msg "Unzipping nibbler archive..."
+msg "Downloading nibbler v${VERSION}..."
+curl -# -fL -O "https://github.com/rooklift/nibbler/archive/refs/tags/v${VERSION}.zip"
 unzip -q "v${VERSION}.zip"
-
 NIBBLER="nibbler-${VERSION}"
 [[ -d "$NIBBLER" ]] && ok "Fetched nibbler!"
 
-ARCH="$(uname -m)"
-if [[ "$ARCH" != "$NODE_ARCH" ]]; then
-	msg "Unsupported architecture: $ARCH (this installer requires ${NODE_ARCH})" >&2
-	exit 1
-fi
+msg "Downloading Electron v${ELECTRON_VERSION}..."
+ELECTRON_ZIP="electron-${ELECTRON_VERSION}-darwin-${ELECTRON_ARCH}.zip"
+curl -# -fL -O "https://github.com/electron/electron/releases/download/${ELECTRON_VERSION}/${ELECTRON_ZIP}"
 
-NODE_DIR="node-v${NODE_VERSION}-darwin-${NODE_ARCH}"
-NODE_TGZ="${NODE_DIR}.tar.gz"
+mkdir -p electron
+cd electron
+unzip -q "../${ELECTRON_ZIP}"
+[[ -d "$WORKDIR/electron/Electron.app" ]] && ok "Fetched Electron!"
 
-msg "Downloading node archive..."
-curl -fL -O "https://nodejs.org/dist/v${NODE_VERSION}/${NODE_TGZ}"
+msg "Assembling Nibbler.app..."
+APP="$WORKDIR/electron/Electron.app"
+APP_ROOT="$APP/Contents/Resources/app"
 
-msg "Unpacking node archive..."
-tar -xzf "$NODE_TGZ"
+rm -f "$APP/Contents/Resources/default_app.asar"
+rm -rf "$APP_ROOT"
+cp -R "$WORKDIR/nibbler-${VERSION}/files/src" "$APP_ROOT"
 
-[[ -d "$NODE_DIR" ]] && ok "Fetched node!"
+PLIST="$APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName Nibbler" "$PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName Nibbler" "$PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.rooklift.nibbler" "$PLIST"
 
-msg "Verifying npm, npx..."
-NODE="$WORKDIR/$NODE_DIR/bin/node"
-NPM="$WORKDIR/$NODE_DIR/bin/npm"
-NPX="$WORKDIR/$NODE_DIR/bin/npx"
+mv "$APP" "$WORKDIR/electron/Nibbler.app"
+ok "Built Nibbler.app!"
 
-"$NODE" --version
-"$NPM" --version
-"$NPX" --version
-
-cd "$WORKDIR/$NIBBLER"
-
-msg "Installing electron and electron-packager..."
-"$NPM" install --save-dev electron @electron/packager
-ok "Installed packages!"
-
-cd "$WORKDIR/$NIBBLER/$SOURCE_DIR"
-
-msg "Running electron-packager..."
-"$NPX" @electron/packager . Nibbler --platform=darwin --arch="$NODE_ARCH" --out=dist
-ok "Built app!"
-
-
-cd "$WORKDIR/$NIBBLER"
-APP_DIR="$WORKDIR/$NIBBLER/$SOURCE_DIR/dist/Nibbler-darwin-${NODE_ARCH}"
+APP_DIR="$WORKDIR/electron"
 APP="$APP_DIR/Nibbler.app"
 APPS_DIR="$HOME/Applications"
 APPS_APP="$APPS_DIR/Nibbler.app"


### PR DESCRIPTION
# One-line installer for MacOS, no codesigning issues!
Hello nibbler contributors, thanks for the amazing project. I learned of nibbler through a close friend, who is a competitive chess player.

## The problem
Installing nibbler can be quite an ordeal for Mac users. This was the case for my aforementioned friend, who is the 'please just hand me the .app' type of person. This was her, and perhaps many others', situation:
* needs quick, non-technical, dependency-free installation
* doesn't really understand how codesigning works on Mac, so prebuilt apps without Apple's notarization is unacceptable (the instructions to override this feel too technical)

Virtually all community-built apps are unsigned, which made installation difficult on Mac.

## The solution
Added new script `files/scripts/installer-macos.sh`. Works out-of-the-box on a fresh Mac without dependency chains (such as the 1GB Xcode CLT). Updated README accordingly.

### Demo video
![demo](https://github.com/user-attachments/assets/64ba2a4d-b8ed-478d-9f91-dd7bc16b916b)

## Note
This is built for & tested on Apple Silicon Macs.
Works pretty fast, around 30 seconds on the slowest Apple Silicon Mac with modest internet bandwidth.
**App built locally, so no codesigning issues are invoked.**

I totally understand if the devs are reluctant to merge this; any feedback will be greatly appreciated!